### PR TITLE
Fix kernel v4.12 support

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1747,10 +1747,17 @@ enum nl80211_iftype {
 	NL80211_IFTYPE_MAX = NUM_NL80211_IFTYPES - 1
 };
 #endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
+				     struct net_device *ndev,
+				     enum nl80211_iftype type,
+				     struct vif_params *params)
+#else
 static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
 				     struct net_device *ndev,
 				     enum nl80211_iftype type, u32 *flags,
 				     struct vif_params *params)
+#endif
 {
 	enum nl80211_iftype old_type;
 	NDIS_802_11_NETWORK_INFRASTRUCTURE networkType;
@@ -3719,7 +3726,11 @@ static int
 		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 		unsigned char name_assign_type,
 		#endif
+		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0))
+		enum nl80211_iftype type, struct vif_params *params)
+		#else
 		enum nl80211_iftype type, u32 *flags, struct vif_params *params)
+		#endif
 {
 	int ret = 0;
 	struct net_device *ndev = NULL;


### PR DESCRIPTION
https://github.com/paspro/rtl8812au/commit/3f0b82e2a9489608ceb97f56db20588a28132dc4 is incomplete and does not build with 4.12.0.

I can confirm this builds against 4.12.0 (but also needs #1, ideally a correct version).